### PR TITLE
add options for custom uids, gids

### DIFF
--- a/src/receipt/bom.rs
+++ b/src/receipt/bom.rs
@@ -24,12 +24,14 @@ use crate::Bom;
 /// Configuration for creating a receipt.
 pub struct ReceiptBuilder {
     paths_only: bool,
+    override_uid: Option<u32>,
+    override_gid: Option<u32>,
 }
 
 impl ReceiptBuilder {
     /// Create receipt builder with the default parameters.
     pub fn new() -> Self {
-        Self { paths_only: false }
+        Self { paths_only: false, override_uid: None, override_gid: None }
     }
 
     /// Do not include metadata in the receipt, include only file paths.
@@ -38,9 +40,21 @@ impl ReceiptBuilder {
         self
     }
 
+    /// Replace uid's.
+    pub fn override_uid(mut self, value: u32) -> Self {
+        self.override_uid = Some(value);
+        self
+    }
+
+    /// Replace gid's.
+    pub fn override_gid(mut self, value: u32) -> Self {
+        self.override_gid = Some(value);
+        self
+    }
+
     /// Create a receipt using the provided parameters.
     pub fn create<P: AsRef<Path>>(self, directory: P) -> Result<Receipt, Error> {
-        let entries = PathComponentVec::from_dir(directory, self.paths_only)?;
+        let entries = PathComponentVec::from_dir(directory, self.paths_only, self.override_uid, self.override_gid)?;
         Ok(Receipt { entries })
     }
 }

--- a/src/receipt/metadata.rs
+++ b/src/receipt/metadata.rs
@@ -83,9 +83,17 @@ impl Metadata {
         get_common_field!(self, uid, 0)
     }
 
+    fn set_uid(&mut self, value: u32) {
+        set_common_field!(self, uid, value);
+    }
+
     /// Get file owner's group id.
     pub fn gid(&self) -> u32 {
         get_common_field!(self, gid, 0)
+    }
+
+    fn set_gid(&mut self, value: u32) {
+        set_common_field!(self, gid, value);
     }
 
     /// Get file's last modification time.
@@ -125,7 +133,7 @@ impl Metadata {
     }
 
     /// Create metadata from the provided file path.
-    pub fn new(path: &Path, path_only: bool) -> Result<Self, Error> {
+    pub fn new(path: &Path, path_only: bool, override_uid: Option<u32>, override_gid: Option<u32>) -> Result<Self, Error> {
         let metadata = std::fs::symlink_metadata(path)?;
         if path_only {
             return Ok(Self::Entry(Entry {
@@ -133,6 +141,15 @@ impl Metadata {
             }));
         }
         let mut metadata: Metadata = metadata.try_into()?;
+
+        if let Some(uid) = override_uid {
+            metadata.set_uid(uid);
+        }
+
+        if let Some(gid) = override_gid {
+            metadata.set_gid(gid);
+        }
+
         match metadata {
             Metadata::File(File {
                 ref mut checksum, ..

--- a/src/receipt/path_component.rs
+++ b/src/receipt/path_component.rs
@@ -203,7 +203,7 @@ impl PathComponentVec {
     }
 
     /// Create a vector by recursively scanning the provided directory.
-    pub fn from_dir<P: AsRef<Path>>(directory: P, paths_only: bool) -> Result<Self, Error> {
+    pub fn from_dir<P: AsRef<Path>>(directory: P, paths_only: bool, override_uid: Option<u32>, override_gid: Option<u32>) -> Result<Self, Error> {
         let directory = directory.as_ref();
         let mut components: HashMap<PathBuf, PathComponent> = HashMap::new();
         // Id starts with 1.
@@ -222,7 +222,8 @@ impl PathComponentVec {
             };
             let dirname = relative_path.parent();
             let basename = relative_path.file_name();
-            let metadata = Metadata::new(entry.path(), paths_only)?;
+            let metadata = Metadata::new(entry.path(), paths_only, override_uid, override_gid)?;
+
             let parent = match dirname {
                 Some(d) => components.get(d).map(|node| node.seq_no).unwrap_or(0),
                 None => 0,
@@ -345,8 +346,8 @@ mod tests {
                     HardLink,
                 ])
                 .create(u)?;
-            let paths_only = u.arbitrary()?;
-            let nodes = PathComponentVec::from_dir(directory.path(), paths_only).unwrap();
+            let (paths_only, override_uid, override_gid) = u.arbitrary()?;
+            let nodes = PathComponentVec::from_dir(directory.path(), paths_only, override_uid, override_gid).unwrap();
             Ok(nodes)
         }
     }


### PR DESCRIPTION
Provide a way for users to map root:wheel entries without resorting to sudo.

Relates to https://github.com/igankevich/stuckliste/issues/9