### PR TITLE
fix missing entries (eg ./._bin) and encourage reproducible artifacts

### DIFF
--- a/src/receipt/path_component.rs
+++ b/src/receipt/path_component.rs
@@ -213,7 +213,7 @@ impl PathComponentVec {
         let mut components: HashMap<PathBuf, PathComponent> = HashMap::new();
         // Id starts with 1.
         let mut seq_no: u32 = 1;
-        for entry in WalkDir::new(directory).into_iter() {
+        for entry in WalkDir::new(directory).sort_by_file_name().into_iter() {
             let entry = entry?;
             let entry_path = entry
                 .path()


### PR DESCRIPTION
When the source directory contains AppleDouble resource forks (eg `./._bin`), then stuckliste sometimes corrupts the `Bom` file, causing the entry row to be missing from `lsbom`.

Sorting the source directory lexicographically, mitigates this problem.

As well, applying a predictable sort order, increases the determinism, reproducibility, debuggabliity, and deployment reliability of build artifacts.